### PR TITLE
Job run logic fixed. Now job's url is available in report in case of  hanging of the tests (closes #29)

### DIFF
--- a/src/saucelabs/job.js
+++ b/src/saucelabs/job.js
@@ -177,8 +177,6 @@ export default class Job {
                 jobResult = await this.run();
             }
             else {
-                this.status = Job.STATUSES.FAILED;
-
                 jobResult = {
                     platform: this.platform,
                     job_id:   this.browser.sessionID

--- a/src/saucelabs/report.js
+++ b/src/saucelabs/report.js
@@ -9,7 +9,7 @@ function checkFailures (results) {
         var msg      = [];
         var platform = [platformResults.platform[0], platformResults.platform[1], platformResults.platform[2] ||
                                                                                   ''].join(' ');
-        var url      = platformResults.url? platformResults.url : 'There is no url attached.' ;
+        var url      = platformResults.url? platformResults.url : 'there is no url attached' ;
 
         var runningError = !platformResults.result || typeof platformResults.result === 'string';
         var failed       = runningError || platformResults.result.failed;


### PR DESCRIPTION
\cc @AlexanderMoskovkin 
PR
