### PR TITLE
Fix the hostname for SauceLabs; Bump version (v1.3.8)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qunit-harness",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "description": "A library for running qunit tests on a local machine and in the SauceLabs environment.",
   "homepage": "https://github.com/AlexanderMoskovkin/qunit-harness",
   "bugs": "https://github.com/AlexanderMoskovkin/qunit-harness/issues",

--- a/src/index.js
+++ b/src/index.js
@@ -402,7 +402,7 @@ export default class QUnitServer extends EventEmitter {
             tags:      settings.tags || curSettings.tags || 'master',
             browsers:  settings.browsers || curSettings.browsers || {},
             name:      settings.name || curSettings.name || 'QUnit tests',
-            urls:      [this.localhostname + '/start'],
+            urls:      [this.hostname + '/start'],
             timeout:   settings.timeout || curSettings.timeout || 30
         };
 


### PR DESCRIPTION
Recent SauceLabs update broke navigation to `localhost` for Android. Tests don't run at all:

https://app.saucelabs.com/tests/4c04a69f30bc48ee8da21c42ba38ed5d

This PR fixes it:

https://app.saucelabs.com/tests/71426789abc5450ea58e4f2eeac79b96

At least they can start now.