### PR TITLE
Fix test run on safari 15

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,0 +1,7 @@
+{
+    "dependencies": {
+        "graceful-fs": {
+            "version": "4.2.2"
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qunit-harness",
-  "version": "1.3.10",
+  "version": "1.3.11",
   "description": "A library for running qunit tests on a local machine and in the SauceLabs environment.",
   "homepage": "https://github.com/AlexanderMoskovkin/qunit-harness",
   "bugs": "https://github.com/AlexanderMoskovkin/qunit-harness/issues",

--- a/src/utils/is-safari-15.js
+++ b/src/utils/is-safari-15.js
@@ -1,0 +1,5 @@
+export default function isSafari15 (browserInfo) {
+    return browserInfo &&
+        browserInfo.browserName === 'safari' &&
+        browserInfo.version === '15';
+}


### PR DESCRIPTION
Changes:
* add delay before test run on Safari 15
* add the `npm-shrinkwrap.json` file to fix the issue with `gulp@3.x` (https://stackoverflow.com/questions/55921442/how-to-fix-referenceerror-primordials-is-not-defined-in-node-js)